### PR TITLE
修复安装时读取文件编码错误

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@
 
 from setuptools import setup, find_packages
 
-
-with open('README.md') as f:
+with open('README.md', encoding="utf-8") as f:
     long_description = f.read().split("## User permissions")[0]
 
 setup(


### PR DESCRIPTION
修复安装时候编码错误
```Python
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\XXX\AppData\Local\Temp\pip-install-kaqqsbbk\School-Api\setup.py", line 8, in <module>
        long_description = f.read().split("## User permissions")[0]
    UnicodeDecodeError: 'gbk' codec can't decode byte 0x82 in position 25: illegal multibyte sequence

```